### PR TITLE
"maximum in window" plugin

### DIFF
--- a/joulescope_ui/plugins/__init__.py
+++ b/joulescope_ui/plugins/__init__.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import usb_inrush, histogram, cdf, ccdf
+from . import usb_inrush, histogram, cdf, ccdf, max_window
 
 PLUGINS_BUILTIN = [
     usb_inrush,
     histogram,
     cdf,
     ccdf,
+    max_window
 ]

--- a/joulescope_ui/plugins/max_window.py
+++ b/joulescope_ui/plugins/max_window.py
@@ -1,0 +1,98 @@
+# Copyright 2019 Jetperch LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import numpy as np
+import pyqtgraph as pg
+from PySide2 import QtWidgets
+from .max_window_config_widget import Ui_Dialog
+from . import plugin_helpers
+
+
+log = logging.getLogger(__name__)
+
+PLUGIN = {
+    'name': 'Max Window',
+    'description': 'Maximum sum of voltage/current/power samples in a given time window',
+}
+
+
+class MaxWindow:
+
+    def __init__(self):
+        self._cfg = None
+        self.data = None
+
+    def run_pre(self, data):
+        max_time_len = data._time_range[1] - data._time_range[0]
+        rv = MaxWindowDialog(max_time_len).exec_()
+        if rv is None:
+            return 'Cancelled'
+        self._cfg = rv
+
+    def run(self, data):
+        time_len = self._cfg['time_len']
+        signal = self._cfg['signal']
+
+        max_sum, start, end = plugin_helpers.max_sum_in_window(data, signal, time_len)
+
+        # there is a rounding error when converting between sample number and time of sample
+        # therefore take the start to be max of 0, start
+        self.data = {
+            'max_sum': max_sum,
+            'start': start,
+            'end': end
+        }
+
+    def run_post(self, data):
+        if not self.data:
+            log.exception('Max Window function failed to produce data')
+            return
+
+        start_time = self.data['start'] / data.sample_frequency
+        end_time = self.data['end'] / data.sample_frequency
+
+        data.marker_dual_add(start_time, end_time)
+
+
+class MaxWindowDialog(QtWidgets.QDialog):
+    def __init__(self, max_time_len):
+        QtWidgets.QDialog.__init__(self)
+        self.ui = Ui_Dialog()
+        self.ui.setupUi(self)
+        self.ui.signal.addItem("current")
+        self.ui.signal.addItem("voltage")
+        self.ui.signal.addItem("power")
+        self.ui.time_len.setMaximum(max_time_len)
+
+    def exec_(self):
+        if QtWidgets.QDialog.exec_(self) == 1:
+            time_len = float(self.ui.time_len.value())
+            signal = str(self.ui.signal.currentText())
+            return {
+                'time_len': time_len,
+                'signal': signal,
+            }
+        else:
+            return None
+
+
+def plugin_register(api):
+    """Register the example plugin.
+
+    :param api: The :class:`PluginServiceAPI` instance.
+    :return: True on success any other value on failure.
+    """
+    api.range_tool_register('Max Window', MaxWindow)
+    return True

--- a/joulescope_ui/plugins/max_window.py
+++ b/joulescope_ui/plugins/max_window.py
@@ -47,8 +47,6 @@ class MaxWindow:
 
         max_sum, start, end = plugin_helpers.max_sum_in_window(data, signal, time_len)
 
-        # there is a rounding error when converting between sample number and time of sample
-        # therefore take the start to be max of 0, start
         self.data = {
             'max_sum': max_sum,
             'start': start,

--- a/joulescope_ui/plugins/max_window_config_widget.ui
+++ b/joulescope_ui/plugins/max_window_config_widget.ui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>368</width>
+    <height>123</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Max Window configuration</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Width of window (in seconds)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Signal</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="signal"/>
+     </item>
+     <item row="0" column="1">
+      <widget class="QDoubleSpinBox" name="time_len">
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="minimum">
+        <double>0.001000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/joulescope_ui/plugins/plugin_helpers.py
+++ b/joulescope_ui/plugins/plugin_helpers.py
@@ -15,6 +15,7 @@
 import logging
 import numpy as np
 from math import ceil
+from collections import deque
 
 log = logging.getLogger(__name__)
 
@@ -62,3 +63,24 @@ def cdf(data, signal):
 def ccdf(data, signal):
     _cdf, bin_edges = cdf(data, signal=signal)
     return 1 - _cdf, bin_edges
+
+def max_sum_in_window(data, signal, time_window_len):
+    window_len = int(time_window_len * data.sample_frequency)
+    queue = deque(np.zeros(window_len), maxlen=window_len)
+
+    start = end = 0
+    max_sum = cur_sum = 0
+    j = 0
+
+    for data_chunk in data:
+        for v in data_chunk[signal]['value']:
+            j += 1
+            old_val = queue.popleft()
+            cur_sum += v - old_val
+            queue.append(v)
+            if cur_sum > max_sum:
+                max_sum = cur_sum
+                start = max(0, j - window_len)
+                end   = j
+
+    return max_sum, start, end


### PR DESCRIPTION
Let me know what you think! There is an error sometimes (for smaller ∆t of original markers) where it will give the upper bound of the window above the original markers; I think this is due to rounding errors in converting between sample counts and times. This also existed sometimes for the lower bound of the window, but that is fixed with taking the `min(start, 0)`. 

Do you have thoughts on a solution? Maybe you know some data or methodology that will solve this. 

Thanks for the API example and quick implementation!