### PR TITLE
Feature/317

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file contains the list of changes made to pyjoulescope_ui.
 
 ---
 
-* Utilize range tool signal_default parameter for the default channel. #317
+* Utilized range tool signal_default parameter for the default channel. #317
 
 ## 1.3.4
 

--- a/joulescope_ui/range_tools/cdf.py
+++ b/joulescope_ui/range_tools/cdf.py
@@ -15,7 +15,7 @@
 
 from joulescope_ui import register, N_, pubsub_singleton, P_
 from joulescope_ui.range_tool import RangeToolBase
-from .plugin_helpers import calculate_histogram, normalize_hist
+from .plugin_helpers import calculate_histogram, normalize_hist, signal_combobox_config
 import logging
 import numpy as np
 import pyqtgraph as pg
@@ -175,13 +175,7 @@ class CdfRangeToolDialog(QtWidgets.QDialog):
         self._layout.addWidget(self._signal_label, 0, 0, 1, 1)
         self._signal = QtWidgets.QComboBox(self)
         self._signal.setObjectName("signalComboBox")
-        default_idx = 0
-        for idx, signal_id in enumerate(value['signals']):
-            if signal_id == value['signal_default']:
-                default_idx = idx
-            signal_name = '.'.join(signal_id.split('.')[-2:])
-            self._signal.addItem(signal_name)
-        self._signal.setCurrentIndex(default_idx)
+        signal_combobox_config(self._signal, value)
         self._layout.addWidget(self._signal, 0, 1, 1, 1)
 
         self._num_bins_label = QtWidgets.QLabel(N_('Number of bins (0 for auto)'), self)

--- a/joulescope_ui/range_tools/frequency.py
+++ b/joulescope_ui/range_tools/frequency.py
@@ -14,6 +14,7 @@
 
 from joulescope_ui import register, N_, pubsub_singleton
 from joulescope_ui.range_tool import RangeToolBase, rsp_as_f32
+from .plugin_helpers import signal_combobox_config
 import logging
 import numpy as np
 import pyqtgraph as pg
@@ -222,13 +223,7 @@ class FrequencyRangeToolDialog(QtWidgets.QDialog):
 
         self._signal = QtWidgets.QComboBox(self)
         self._signal.setObjectName("signalComboBox")
-        default_idx = 0
-        for idx, signal_id in enumerate(value['signals']):
-            if signal_id == value['signal_default']:
-                default_idx = idx
-            signal_name = '.'.join(signal_id.split('.')[-2:])
-            self._signal.addItem(signal_name)
-        self._signal.setCurrentIndex(default_idx)
+        signal_combobox_config(self._signal, value)
         self._layout.addWidget(self._signal, 0, 1, 1, 1)
 
         self._windowLabel = QtWidgets.QLabel(self)

--- a/joulescope_ui/range_tools/histogram.py
+++ b/joulescope_ui/range_tools/histogram.py
@@ -18,7 +18,7 @@ from joulescope_ui.range_tool import RangeToolBase
 import logging
 import numpy as np
 import pyqtgraph as pg
-from .plugin_helpers import calculate_histogram, normalize_hist
+from .plugin_helpers import calculate_histogram, normalize_hist, signal_combobox_config
 from joulescope_ui.styles import styled_widget
 
 
@@ -46,14 +46,8 @@ class HistogramRangeToolDialog(QtWidgets.QDialog):
         self._form.setWidget(0, QtWidgets.QFormLayout.LabelRole, self._signal_label)
         self._signal = QtWidgets.QComboBox(self)
         self._form.setWidget(0, QtWidgets.QFormLayout.FieldRole, self._signal)
-        default_idx = 0
-        for idx, signal_id in enumerate(value['signals']):
-            if signal_id == value['signal_default']:
-                default_idx = idx
-            signal_name = '.'.join(signal_id.split('.')[-2:])
-            self._signal.addItem(signal_name)
-        self._signal.setCurrentIndex(default_idx)
-        
+        signal_combobox_config(self._signal, value)
+
         self._num_bins_label = QtWidgets.QLabel(N_('Number of bins (0 for auto)'), self)
         self._form.setWidget(1, QtWidgets.QFormLayout.LabelRole, self._num_bins_label)
         self._num_bins = QtWidgets.QSpinBox(self)

--- a/joulescope_ui/range_tools/max_window.py
+++ b/joulescope_ui/range_tools/max_window.py
@@ -14,6 +14,7 @@
 
 from joulescope_ui import N_, time64, register, pubsub_singleton, get_topic_name, P_
 from joulescope_ui.range_tool import RangeToolBase, rsp_as_f32
+from .plugin_helpers import signal_combobox_config
 import logging
 import numpy as np
 from PySide6 import QtCore, QtWidgets
@@ -121,13 +122,7 @@ class MaxWindowDialog(QtWidgets.QDialog):
 
         self._signal = QtWidgets.QComboBox(self)
         self._form.setWidget(1, QtWidgets.QFormLayout.FieldRole, self._signal)
-        default_idx = 0
-        for idx, signal_id in enumerate(value['signals']):
-            if signal_id == value['signal_default']:
-                default_idx = idx
-            signal_name = '.'.join(signal_id.split('.')[-2:])
-            self._signal.addItem(signal_name)
-        self._signal.setCurrentIndex(default_idx)
+        signal_combobox_config(self._signal, value)
 
         self._layout.addLayout(self._form)
 

--- a/joulescope_ui/range_tools/plugin_helpers.py
+++ b/joulescope_ui/range_tools/plugin_helpers.py
@@ -15,7 +15,7 @@
 import logging
 import numpy as np
 from math import ceil
-
+from PySide6 import QtWidgets
 
 _log = logging.getLogger(__name__)
 
@@ -60,3 +60,13 @@ def normalize_hist(hist, bin_edges, norm: str = None):
         _log.error('_normalize_hist invalid normalization: %s', norm)
     gain = 1 / hist.sum()
     return hist * gain, bin_edges
+
+
+def signal_combobox_config(combobox: QtWidgets.QComboBox, value):
+    default_idx = 0
+    for idx, signal_id in enumerate(value['signals']):
+        if signal_id == value['signal_default']:
+            default_idx = idx
+        signal_name = '.'.join(signal_id.split('.')[-2:])
+        combobox.addItem(signal_name)
+    combobox.setCurrentIndex(default_idx)


### PR DESCRIPTION
This branch implements the code discussed in https://forum.joulescope.com/t/feature-suggestion-for-waveform-view-analysis-tool-default-signal-based-on-mouse-position-when-right-clicking/1011/3 , and uses the already existing signal_default parameter to make the default channel of a dual marker analysis be the one the mouse was over during the right-click (and of the selected Joulescope).
I've done brief testing with 2 JS220s and encountered no issues. All the visible channels of both scopes were available.
The pylint scores for the individual files are slightly negative due to having less code. Running multiple files might have a net positive change, but I didn't run it.